### PR TITLE
Sequenced mode of operation

### DIFF
--- a/custom_components/dantherm/const.py
+++ b/custom_components/dantherm/const.py
@@ -132,9 +132,11 @@ class DanthermSelectEntityDescription(SelectEntityDescription):
     """Dantherm Select Entity Description."""
 
     data_setaddress: int | None = None
+    data_setinternal: str | None = None
     data_setclass: DataClass | None = None
 
     data_address: int | None = None
+    data_getinternal: str | None = None
     data_entity: str | None = None
     data_bitwise_and: int | None = None
     data_exclude_if: Any | None = None
@@ -148,6 +150,7 @@ class DanthermSensorEntityDescription(SensorEntityDescription):
     """Dantherm Sensor Entity Description."""
 
     data_address: int | None = None
+    data_getinternal: str | None = None
     data_precision: int | None = None
     data_scale: int | None = None
     data_exclude_if: Any | None = None
@@ -163,6 +166,8 @@ class DanthermSwitchEntityDescription(SwitchEntityDescription):
     """Dantherm Switch Entity Description."""
 
     data_setaddress: int | None = None
+    data_setinternal: str | None = None
+    data_getinternal: str | None = None
     data_setclass: DataClass | None = None
     state_suspend_for: int | None = None
     state_on: int = None
@@ -226,17 +231,14 @@ NUMBER_TYPES: dict[str, list[DanthermNumberEntityDescription]] = {
 SELECT_TYPES: dict[str, list[DanthermSelectEntityDescription]] = {
     "operation_selection": DanthermSelectEntityDescription(
         key="operation_selection",
-        data_setaddress=168,
-        data_entity="active_unit_mode",
-        data_bitwise_and=0x0F,
-        data_class=DataClass.UInt32,
-        options=["2", "4", "8"],
+        data_setinternal="set_op_selection",
+        data_getinternal="get_op_selection",
+        options=["0", "1", "2", "3"],
     ),
     "fan_level_selection": DanthermSelectEntityDescription(
         key="fan_level_selection",
-        data_setaddress=324,
-        data_entity="fan_level",
-        data_class=DataClass.UInt32,
+        data_setinternal="set_fan_level",
+        data_getinternal="get_fan_level",
         options=["0", "1", "2", "3", "4"],
     ),
     "week_program_selection": DanthermSelectEntityDescription(
@@ -248,22 +250,9 @@ SELECT_TYPES: dict[str, list[DanthermSelectEntityDescription]] = {
 }
 
 SENSOR_TYPES: dict[str, list[DanthermSensorEntityDescription]] = {
-    "current_unit_mode": DanthermSensorEntityDescription(
-        key="current_unit_mode",
-        data_class=DataClass.UInt32,
-        data_address=472,
-        entity_registry_visible_default=False,
-    ),
-    "active_unit_mode": DanthermSensorEntityDescription(
-        key="active_unit_mode",
-        data_class=DataClass.UInt16,
-        data_address=168,
-        entity_registry_visible_default=False,
-    ),
     "operation_mode": DanthermSensorEntityDescription(
         key="operation_mode",
-        data_entity="current_unit_mode",
-        data_class=DataClass.UInt32,
+        data_getinternal="get_current_unit_mode",
     ),
     "alarm": DanthermSensorEntityDescription(
         key="alarm",
@@ -274,8 +263,7 @@ SENSOR_TYPES: dict[str, list[DanthermSensorEntityDescription]] = {
     "fan_level": DanthermSensorEntityDescription(
         key="fan_level",
         icon="mdi:fan",
-        data_class=DataClass.UInt32,
-        data_address=324,
+        data_getinternal="get_fan_level",
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "fan1_rpm": DanthermSensorEntityDescription(
@@ -365,9 +353,8 @@ SENSOR_TYPES: dict[str, list[DanthermSensorEntityDescription]] = {
 SWITCH_TYPES: dict[str, list[DanthermSwitchEntityDescription]] = {
     "away_mode": DanthermSwitchEntityDescription(
         key="away_mode",
-        data_class=DataClass.UInt32,
-        data_setaddress=168,
-        data_entity="active_unit_mode",
+        data_setinternal="set_active_unit_mode",
+        data_getinternal="get_active_unit_mode",
         state_suspend_for=30,
         state_on=0x10,
         icon_on="mdi:briefcase-outline",
@@ -377,9 +364,8 @@ SWITCH_TYPES: dict[str, list[DanthermSwitchEntityDescription]] = {
     ),
     "night_mode": DanthermSwitchEntityDescription(
         key="night_mode",
-        data_class=DataClass.UInt32,
-        data_setaddress=168,
-        data_entity="active_unit_mode",
+        data_setinternal="set_active_unit_mode",
+        data_getinternal="get_active_unit_mode",
         state_suspend_for=30,
         state_on=0x20,
         icon_on="mdi:weather-night",
@@ -389,9 +375,8 @@ SWITCH_TYPES: dict[str, list[DanthermSwitchEntityDescription]] = {
     ),
     "fireplace_mode": DanthermSwitchEntityDescription(
         key="fireplace_mode",
-        data_class=DataClass.UInt32,
-        data_setaddress=168,
-        data_entity="active_unit_mode",
+        data_setinternal="set_active_unit_mode",
+        data_getinternal="get_active_unit_mode",
         state_suspend_for=30,
         state_on=0x40,
         icon_on="mdi:fireplace",
@@ -401,9 +386,8 @@ SWITCH_TYPES: dict[str, list[DanthermSwitchEntityDescription]] = {
     ),
     "manual_bypass_mode": DanthermSwitchEntityDescription(
         key="manual_bypass_mode",
-        data_class=DataClass.UInt32,
-        data_setaddress=168,
-        data_entity="active_unit_mode",
+        data_setinternal="set_active_unit_mode",
+        data_getinternal="get_active_unit_mode",
         state_suspend_for=30,
         state_on=0x80,
         icon_on="mdi:arrow-decision-outline",
@@ -414,9 +398,8 @@ SWITCH_TYPES: dict[str, list[DanthermSwitchEntityDescription]] = {
     ),
     "summer_mode": DanthermSwitchEntityDescription(
         key="summer_mode",
-        data_class=DataClass.UInt32,
-        data_setaddress=168,
-        data_entity="active_unit_mode",
+        data_setinternal="set_active_unit_mode",
+        data_getinternal="get_active_unit_mode",
         state_suspend_for=30,
         state_on=0x800,
         icon_on="mdi:emoticon-cool-outline",

--- a/custom_components/dantherm/select.py
+++ b/custom_components/dantherm/select.py
@@ -49,14 +49,21 @@ class DanthermSelect(SelectEntity, DanthermEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
 
-        await self._device.write_holding_registers(
-            description=self.entity_description, value=int(option)
-        )
+        if self.entity_description.data_setinternal:
+            await getattr(self._device, self.entity_description.data_setinternal)(
+                int(option)
+            )
+        else:
+            await self._device.write_holding_registers(
+                description=self.entity_description, value=int(option)
+            )
 
     async def async_update(self) -> None:
         """Fetch new state data for the select."""
 
-        if self.entity_description.data_entity:
+        if self.entity_description.data_getinternal:
+            result = getattr(self._device, self.entity_description.data_getinternal)
+        elif self.entity_description.data_entity:
             result = self._device.data.get(self.entity_description.data_entity, None)
         else:
             result = await self._device.read_holding_registers(

--- a/custom_components/dantherm/sensor.py
+++ b/custom_components/dantherm/sensor.py
@@ -54,7 +54,9 @@ class DanthermSensor(SensorEntity, DanthermEntity):
     async def async_update(self) -> None:
         """Read holding register."""
 
-        if self.entity_description.data_entity:
+        if self.entity_description.data_getinternal:
+            result = getattr(self._device, self.entity_description.data_getinternal)
+        elif self.entity_description.data_entity:
             result = self._device.data.get(self.entity_description.data_entity, None)
         else:
             result = await self._device.read_holding_registers(

--- a/custom_components/dantherm/switch.py
+++ b/custom_components/dantherm/switch.py
@@ -54,9 +54,15 @@ class DanthermSwitch(SwitchEntity, DanthermEntity):
             self.suspend_refresh(self.entity_description.state_suspend_for)
 
         self._attr_is_on = False
-        await self._device.write_holding_registers(
-            description=self.entity_description, value=self.entity_description.state_off
-        )
+        if self.entity_description.data_setinternal:
+            await getattr(self._device, self.entity_description.data_setinternal)(
+                self.entity_description.state_off
+            )
+        else:
+            await self._device.write_holding_registers(
+                description=self.entity_description,
+                value=self.entity_description.state_off,
+            )
 
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
@@ -65,9 +71,15 @@ class DanthermSwitch(SwitchEntity, DanthermEntity):
             self.suspend_refresh(self.entity_description.state_suspend_for)
 
         self._attr_is_on = True
-        await self._device.write_holding_registers(
-            description=self.entity_description, value=self.entity_description.state_on
-        )
+        if self.entity_description.data_setinternal:
+            await getattr(self._device, self.entity_description.data_setinternal)(
+                self.entity_description.state_on
+            )
+        else:
+            await self._device.write_holding_registers(
+                description=self.entity_description,
+                value=self.entity_description.state_on,
+            )
 
     async def async_update(self) -> None:
         """Read holding register."""
@@ -77,7 +89,9 @@ class DanthermSwitch(SwitchEntity, DanthermEntity):
                 _LOGGER.debug("Skipping suspened entity=%s", self.name)
                 return
 
-        if self.entity_description.data_entity:
+        if self.entity_description.data_getinternal:
+            result = getattr(self._device, self.entity_description.data_getinternal)
+        elif self.entity_description.data_entity:
             result = self._device.data.get(self.entity_description.data_entity, None)
         else:
             result = await self._device.read_holding_registers(

--- a/custom_components/dantherm/translations/da.json
+++ b/custom_components/dantherm/translations/da.json
@@ -33,15 +33,16 @@
       "operation_selection": {
         "name": "Driftindstilling",
         "state": {
-          "2": "Efterspørgsel",
-          "4": "Manuel",
-          "8": "Ugerogram"
+          "0": "Standby",
+          "1": "Automatik",
+          "2": "Manuel",
+          "3": "Ugerogram"
         }
       },
       "fan_level_selection": {
         "name": "Ventilatorindstilling",
         "state": {
-          "0": "Stoppet",
+          "0": "Hastighed 0",
           "1": "Hastighed 1",
           "2": "Hastighed 2",
           "3": "Hastighed 3",
@@ -70,7 +71,7 @@
         "state": {
           "0": "Standby",
           "1": "Manuel tilstand",
-          "2": "Efterspørgselstilstand",
+          "2": "Automatik tilstand",
           "3": "Ugeprogram tilstand",
           "4": "Servoflow",
           "5": "Bortrejst tilstand",
@@ -108,7 +109,7 @@
           "15": "Høj Vandstand alarm"
         }
       },
-      "fan_level": { "name": "Ventilator niveau" },
+      "fan_level": { "name": "Ventilatorniveau" },
       "fan1_speed": { "name": "Ventilatorhastighed 1" },
       "fan2_speed": { "name": "Ventilatorhastighed 2" },
       "humidity": { "name": "Luftfugtighed" },

--- a/custom_components/dantherm/translations/en.json
+++ b/custom_components/dantherm/translations/en.json
@@ -33,15 +33,16 @@
       "operation_selection": {
         "name": "Operation Selection",
         "state": {
-          "2": "Demand",
-          "4": "Manual",
-          "8": "Week Program"
+          "0": "Standby",
+          "1": "Automatic",
+          "2": "Manual",
+          "3": "Week Program"
         }
       },
       "fan_level_selection": {
         "name": "Fan Selection",
         "state": {
-          "0": "Standby",
+          "0": "Level 0",
           "1": "Level 1",
           "2": "Level 2",
           "3": "Level 3",
@@ -70,7 +71,7 @@
         "state": {
           "0": "Standby",
           "1": "Manual Mode",
-          "2": "Demand Mode",
+          "2": "Automatic Mode",
           "3": "Weekprogram Mode",
           "4": "Servoflow",
           "5": "Away Mode",
@@ -108,7 +109,7 @@
           "15": "High Waterlevel Alarm"
         }
       },
-      "fan_level": { "name": "Ventilator niveau" },
+      "fan_level": { "name": "Fan Level" },
       "fan1_speed": { "name": "Fan Speed 1" },
       "fan2_speed": { "name": "Fan Speed 2" },
       "humidity": { "name": "Humidity" },


### PR DESCRIPTION
Made the hidden sensors "Current Unit Mode" and "Active Unit Mode" into internal function on the Device. Changed the "Operation Selection" to have sequensed numbers instead of bit sequences. Added a "Standby" operation selection. This chooses "Manual Mode" and a fan level of 0 in one go. Changed naming decisions in the translation.