### PR TITLE
Fix README grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Known supported units:
 <!-- START:shared-section no-replace -->
 The listed units are known to work with this integration. Basically, all units compatible with the **_Dantherm Residential_** or **_Pluggit iFlow_** apps should work with the integration as well.
 
-Users has reported that the integration also works with the **Bosch Vent 5000 C** and **Fränkische Profi-Air Flex** ventilation units.
+Users have reported that the integration also works with the **Bosch Vent 5000 C** and **Fränkische Profi-Air Flex** ventilation units.
 <!-- END:shared-section -->
 
 > [!NOTE]  


### PR DESCRIPTION
Correct subject-verb agreement in README.md: change "Users has reported" to "Users have reported" in the Known supported units section referring to Bosch Vent 5000 C and Fränkische Profi-Air Flex.