### PR TITLE
Add discovery option to config flow

### DIFF
--- a/custom_components/dantherm/config_flow.py
+++ b/custom_components/dantherm/config_flow.py
@@ -122,7 +122,7 @@ class DanthermConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._manufacturer: str | None = None
         self._use_discovery: bool = (
-            False  # Default to False, only enabled via manufacturer step
+            False  # Default to False; set in the discovery_option step
         )
         self._discovery_configured = False
 

--- a/custom_components/dantherm/config_flow.py
+++ b/custom_components/dantherm/config_flow.py
@@ -148,7 +148,7 @@ class DanthermConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_discovery_option(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle discovery selection when manufacturer step is skipped."""
+        """Handle the discovery selection step before continuing to user setup."""
         if user_input is not None:
             self._use_discovery = user_input.get(CONF_USE_DISCOVERY, False)
             self._discovery_configured = True

--- a/custom_components/dantherm/config_flow.py
+++ b/custom_components/dantherm/config_flow.py
@@ -124,7 +124,7 @@ class DanthermConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._use_discovery: bool = (
             False  # Default to False; set in the discovery_option step
         )
-        self._discovery_configured = False
+        self._discovery_configured: bool = False
 
     def _host_in_configuration_exists(self, host: str) -> bool:
         """Return True if host exists in configuration."""

--- a/custom_components/dantherm/config_flow.py
+++ b/custom_components/dantherm/config_flow.py
@@ -62,6 +62,15 @@ def _get_manufacturer_schema() -> vol.Schema:
             vol.Required(CONF_MANUFACTURER, default=DEFAULT_NAME): vol.In(
                 manufacturers
             ),
+        }
+    )
+
+
+def _get_discovery_schema() -> vol.Schema:
+    """Return the schema for the discovery selection step."""
+
+    return vol.Schema(
+        {
             vol.Optional(CONF_USE_DISCOVERY, default=False): bool,
         }
     )
@@ -115,6 +124,7 @@ class DanthermConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._use_discovery: bool = (
             False  # Default to False, only enabled via manufacturer step
         )
+        self._discovery_configured = False
 
     def _host_in_configuration_exists(self, host: str) -> bool:
         """Return True if host exists in configuration."""
@@ -128,12 +138,25 @@ class DanthermConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the manufacturer selection step."""
         if user_input is not None:
             self._manufacturer = user_input[CONF_MANUFACTURER]
-            self._use_discovery = user_input.get(CONF_USE_DISCOVERY, False)
-            return await self.async_step_user()
+            return await self.async_step_discovery_option()
 
         return self.async_show_form(
             step_id=CONF_MANUFACTURER,
             data_schema=_get_manufacturer_schema(),
+        )
+
+    async def async_step_discovery_option(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle discovery selection when manufacturer step is skipped."""
+        if user_input is not None:
+            self._use_discovery = user_input.get(CONF_USE_DISCOVERY, False)
+            self._discovery_configured = True
+            return await self.async_step_user()
+
+        return self.async_show_form(
+            step_id="discovery_option",
+            data_schema=_get_discovery_schema(),
         )
 
     async def async_step_user(
@@ -144,6 +167,9 @@ class DanthermConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if USE_MANUFACTURER_MAP and self._manufacturer is None:
             return await self.async_step_manufacturer()
+
+        if not self._discovery_configured:
+            return await self.async_step_discovery_option()
 
         if user_input is None:
             default_name = DEFAULT_NAME

--- a/custom_components/dantherm/translations/da.json
+++ b/custom_components/dantherm/translations/da.json
@@ -5,7 +5,13 @@
         "title": "Vælg Producent",
         "description": "Vælg producenten af din ventilationsenhed.",
         "data": {
-          "manufacturer": "Producent",
+          "manufacturer": "Producent"
+        }
+      },
+      "discovery_option": {
+        "title": "Discovery",
+        "description": "Vælg om der skal anvendes automatisk enhedsopdagelse.",
+        "data": {
           "use_discovery": "Anvend automatisk enhedsopdagelse"
         }
       },

--- a/custom_components/dantherm/translations/de.json
+++ b/custom_components/dantherm/translations/de.json
@@ -5,7 +5,13 @@
         "title": "Hersteller auswählen",
         "description": "Wählen Sie den Hersteller Ihrer Lüftungsanlage.",
         "data": {
-          "manufacturer": "Hersteller",
+          "manufacturer": "Hersteller"
+        }
+      },
+      "discovery_option": {
+        "title": "Discovery",
+        "description": "Wählen Sie, ob die automatische Gerätesuche verwendet werden soll.",
+        "data": {
           "use_discovery": "Automatische Gerätesuche verwenden"
         }
       },

--- a/custom_components/dantherm/translations/en.json
+++ b/custom_components/dantherm/translations/en.json
@@ -5,7 +5,13 @@
         "title": "Select Manufacturer",
         "description": "Choose the manufacturer of your ventilation unit.",
         "data": {
-          "manufacturer": "Manufacturer",
+          "manufacturer": "Manufacturer"
+        }
+      },
+      "discovery_option": {
+        "title": "Discovery",
+        "description": "Choose whether to use automatic device discovery.",
+        "data": {
           "use_discovery": "Use automatic device discovery"
         }
       },

--- a/custom_components/dantherm/translations/fr.json
+++ b/custom_components/dantherm/translations/fr.json
@@ -5,7 +5,13 @@
         "title": "Sélectionner le fabricant",
         "description": "Choisissez le fabricant de votre unité de ventilation.",
         "data": {
-          "manufacturer": "Fabricant",
+          "manufacturer": "Fabricant"
+        }
+      },
+      "discovery_option": {
+        "title": "Discovery",
+        "description": "Choisissez si la découverte automatique des appareils doit être utilisée.",
+        "data": {
           "use_discovery": "Utiliser la découverte automatique des appareils"
         }
       },

--- a/custom_components/dantherm/translations/nl.json
+++ b/custom_components/dantherm/translations/nl.json
@@ -5,7 +5,13 @@
         "title": "Selecteer fabrikant",
         "description": "Kies de fabrikant van uw ventilatie-eenheid.",
         "data": {
-          "manufacturer": "Fabrikant",
+          "manufacturer": "Fabrikant"
+        }
+      },
+      "discovery_option": {
+        "title": "Discovery",
+        "description": "Kies of automatische apparaatdetectie moet worden gebruikt.",
+        "data": {
           "use_discovery": "Gebruik automatische apparaatdetectie"
         }
       },


### PR DESCRIPTION
Introduce a discovery selection step in the Dantherm config flow so users can opt into automatic device discovery. Adds _get_discovery_schema and async_step_discovery_option, a _discovery_configured flag, and routes manufacturer/user steps to the new discovery step. Updates translations (da, de, en, fr, nl) to include the discovery_option strings. Default behavior keeps discovery disabled unless explicitly chosen.