### PR TITLE
Add coordinator async_shutdown and cancel tasks

### DIFF
--- a/custom_components/dantherm/__init__.py
+++ b/custom_components/dantherm/__init__.py
@@ -485,7 +485,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         if domain_data.get(ATTR_CALENDAR) is not None:
             try:
                 owner_id = getattr(domain_data[ATTR_CALENDAR], "_config_entry_id", None)
-            except AttributeError, TypeError:
+            except (AttributeError, TypeError):
                 owner_id = None
             if owner_id == entry.entry_id:
                 domain_data.pop(ATTR_CALENDAR, None)

--- a/custom_components/dantherm/__init__.py
+++ b/custom_components/dantherm/__init__.py
@@ -386,6 +386,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await device.async_start()
     except Exception:
         _LOGGER.exception("Failed to start device")
+        await coordinator.async_shutdown()
+        await device.disconnect_and_close()
+        hass.data[DOMAIN].pop(entry.entry_id, None)
         return False
 
     async def _init_after_start(event: Event | None = None) -> None:
@@ -449,9 +452,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Check if this entry was primary before unload
     was_primary = is_primary_entry(hass, entry.entry_id)
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        coordinator = entry_data.get("coordinator")
+        if coordinator is not None:
+            await coordinator.async_shutdown()
         hass.data[DOMAIN].pop(entry.entry_id, None)
 
         # Promote and reload new primary, so it can create shared calendar
@@ -478,7 +485,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         if domain_data.get(ATTR_CALENDAR) is not None:
             try:
                 owner_id = getattr(domain_data[ATTR_CALENDAR], "_config_entry_id", None)
-            except (AttributeError, TypeError):
+            except AttributeError, TypeError:
                 owner_id = None
             if owner_id == entry.entry_id:
                 domain_data.pop(ATTR_CALENDAR, None)

--- a/custom_components/dantherm/coordinator.py
+++ b/custom_components/dantherm/coordinator.py
@@ -96,6 +96,7 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
         # Event to wake backend processor
         self._backend_event = asyncio.Event()
         self._backend_busy = False
+        self._shutdown_requested = False
 
         # Pending action tracking
         self._pending_actions: dict[str, PendingActionState] = {}
@@ -124,8 +125,39 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
         }
 
         # Start processors
-        hass.loop.create_task(self._process_frontend())
-        hass.loop.create_task(self._process_backend())
+        self._frontend_task = hass.loop.create_task(self._process_frontend())
+        self._backend_task = hass.loop.create_task(self._process_backend())
+
+    async def async_shutdown(self) -> None:
+        """Stop background queue processors and fail queued work."""
+        if self._shutdown_requested:
+            return
+
+        self._shutdown_requested = True
+
+        while not self._frontend_queue.empty():
+            _, _, _, fut = self._frontend_queue.get_nowait()
+            if not fut.done():
+                fut.cancel()
+            self._frontend_queue.task_done()
+
+        while self._backend_queue:
+            _, _, _, fut = self._backend_queue.popleft()
+            if not fut.done():
+                fut.cancel()
+
+        self._backend_event.set()
+
+        tasks = [
+            task
+            for task in (self._frontend_task, self._backend_task)
+            if not task.done()
+        ]
+        for task in tasks:
+            task.cancel()
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def schedule_reload(self) -> None:
         """Flag the integration to reload on the next update."""
@@ -310,7 +342,10 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
     async def _process_frontend(self) -> None:
         """Run frontend tasks in sequence, waiting for backend writes after each."""
         while True:
-            func, args, kwargs, fut = await self._frontend_queue.get()
+            try:
+                func, args, kwargs, fut = await self._frontend_queue.get()
+            except asyncio.CancelledError:
+                return
             try:
                 _LOGGER.debug("Frontend: executing %s", func.__name__)
                 # run the user-level coroutine
@@ -320,6 +355,10 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
                 # finally, set the future’s result
                 if not fut.done():  # check if future is not already done (e.g. by a timeout/exception/cancellation)
                     fut.set_result(result)
+            except asyncio.CancelledError:
+                if not fut.done():
+                    fut.cancel()
+                raise
             except Exception as exc:
                 if not fut.done():  # check if future is not already done
                     fut.set_exception(exc)
@@ -339,7 +378,17 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
         """Sequentially execute raw Modbus writes with locking + delay."""
         while True:
             # Wait until at least one write is enqueued
-            await self._backend_event.wait()
+            try:
+                await self._backend_event.wait()
+            except asyncio.CancelledError:
+                return
+
+            if not self._backend_queue:
+                if self._shutdown_requested:
+                    return
+                self._backend_event.clear()
+                continue
+
             func, args, kwargs, fut = self._backend_queue.popleft()
             if not self._backend_queue:
                 self._backend_event.clear()
@@ -352,6 +401,10 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
                         result = await func(*args, **kwargs)
                         if fut:
                             fut.set_result(result)
+                    except asyncio.CancelledError:
+                        if fut and not fut.done():
+                            fut.cancel()
+                        raise
                     except Exception as exc:
                         _LOGGER.exception("Backend write failed")
                         if fut:
@@ -396,6 +449,7 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
         if (
             not self._entities
         ):  # disconnect and close modbus connection if no more entities
+            await self.async_shutdown()
             await self.hub.disconnect_and_close()
 
     def get_entity(self, entity_id: str) -> Entity | None:

--- a/custom_components/dantherm/coordinator.py
+++ b/custom_components/dantherm/coordinator.py
@@ -134,6 +134,7 @@ class DanthermCoordinator(DataUpdateCoordinator, DanthermStore):
             return
 
         self._shutdown_requested = True
+        await super().async_shutdown()
 
         while not self._frontend_queue.empty():
             _, _, _, fut = self._frontend_queue.get_nowait()

--- a/tests/components/dantherm/test_coordinator.py
+++ b/tests/components/dantherm/test_coordinator.py
@@ -218,8 +218,8 @@ class TestDanthermCoordinator:
 
         await coordinator.async_shutdown()
 
-        assert coordinator._frontend_task.cancelled()
-        assert coordinator._backend_task.cancelled()
+        assert coordinator._frontend_task.done()
+        assert coordinator._backend_task.done()
 
 
 class TestPendingActionLifecycle:

--- a/tests/components/dantherm/test_coordinator.py
+++ b/tests/components/dantherm/test_coordinator.py
@@ -1,26 +1,19 @@
 """Test the Dantherm coordinator."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import config.custom_components.dantherm.coordinator as coordinator_mod
-from config.custom_components.dantherm.coordinator import (
-    DanthermCoordinator,
-    PendingActionState,
-)
+from config.custom_components.dantherm.coordinator import DanthermCoordinator
 from config.custom_components.dantherm.device_map import (
-    ACTION_PENDING_MIN_READ_DELAY_MILLISECONDS,
     ATTR_ACTIONS_PENDING,
-    ATTR_AWAY_MODE,
     DanthermEntityDescription,
     DanthermSwitchEntityDescription,
-    ActiveUnitMode,
 )
 import pytest
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 
 from tests.common import MockConfigEntry
 
@@ -152,10 +145,13 @@ class TestDanthermCoordinator:
         # Initialize data dict and mock disconnect to prevent errors
         coordinator.data = {}
         mock_hub.disconnect_and_close = AsyncMock()
+        coordinator.async_shutdown = AsyncMock()
 
         # Test removing entity (will call disconnect when no entities left)
         await coordinator.async_remove_entity(mock_entity)
         assert mock_entity not in coordinator._entities
+        coordinator.async_shutdown.assert_awaited_once()
+        mock_hub.disconnect_and_close.assert_awaited_once()
 
         await _cancel_coordinator_tasks()
 
@@ -206,6 +202,26 @@ class TestDanthermCoordinator:
         # Test entity installed
         assert coordinator.is_entity_installed("test_entity")
 
+        await _cancel_coordinator_tasks()
+
+    async def test_coordinator_async_shutdown_cancels_background_tasks(
+        self, hass: HomeAssistant, mock_hub, mock_config_entry
+    ) -> None:
+        """Test coordinator shutdown cancels processor tasks."""
+        coordinator = DanthermCoordinator(
+            hass=hass,
+            name="TestDevice",
+            hub=mock_hub,
+            scan_interval=30,
+            config_entry=mock_config_entry,
+        )
+
+        await coordinator.async_shutdown()
+
+        assert coordinator._frontend_task.cancelled()
+        assert coordinator._backend_task.cancelled()
+
+
 class TestPendingActionLifecycle:
     """Tests for coordinator pending-action state machine."""
 
@@ -214,13 +230,16 @@ class TestPendingActionLifecycle:
         """Return a coordinator with a short write_delay for fast tests."""
         import asyncio
         from unittest.mock import MagicMock
+
         from homeassistant.config_entries import ConfigEntry
 
         mock_hass = MagicMock()
         mock_hass.data = {}
 
         mock_hass.loop = MagicMock()
-        mock_hass.loop.create_task = MagicMock(return_value=MagicMock(spec=asyncio.Task))
+        mock_hass.loop.create_task = MagicMock(
+            return_value=MagicMock(spec=asyncio.Task)
+        )
         mock_hass.loop.create_future = asyncio.get_running_loop().create_future
 
         entry = ConfigEntry(
@@ -262,7 +281,7 @@ class TestPendingActionLifecycle:
     ) -> None:
         """Pending clears only when BOTH delay + next cycle are satisfied."""
 
-        t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
         current_time = {"now": t0}
 
         monkeypatch.setattr(coordinator_mod, "ha_now", lambda: current_time["now"])
@@ -363,7 +382,9 @@ class TestPendingActionLifecycle:
         entity.extra_state_attributes = {"existing": "value"}
         coordinator._pending_supported_keys.add("test_action")
 
-        monkeypatch.setattr(coordinator, "is_entity_pending", MagicMock(return_value=True))
+        monkeypatch.setattr(
+            coordinator, "is_entity_pending", MagicMock(return_value=True)
+        )
 
         pending_attr_name = getattr(coordinator_mod, "ATTR_PENDING", "pending")
         inject_pending = coordinator._inject_pending_attr


### PR DESCRIPTION
Introduce DanthermCoordinator.async_shutdown to stop background processors, cancel queued futures, drain queues, wake the backend and await cancellation of frontend/backend tasks. Store created tasks on the coordinator and handle asyncio.CancelledError in frontend/backend loops to allow clean shutdown. Call async_shutdown on setup failure and during unload to ensure no leftover tasks and to disconnect the hub safely. Update unit tests to mock/assert async_shutdown and task cancellation, tidy imports/mocks, and adjust calendar owner exception handling.