### PR TITLE
Enhancement/installed components

### DIFF
--- a/custom_components/dantherm/device.py
+++ b/custom_components/dantherm/device.py
@@ -238,10 +238,7 @@ class DanthermDevice(DanthermModbus, DanthermAdaptiveManager):
         _LOGGER.debug("Setup has started")
 
         # Connect and verify modbus connection
-        if not await self.connect_and_verify():
-            # We shoud never get here since connect_and_verify should raise an exception
-            # if it fails, but just in case, we return None to indicate setup failure
-            return None
+        await self.connect_and_verify()
         _LOGGER.info("Modbus setup completed successfully for %s", self._host)
 
         self.installed_components = 0

--- a/custom_components/dantherm/device.py
+++ b/custom_components/dantherm/device.py
@@ -242,8 +242,11 @@ class DanthermDevice(DanthermModbus, DanthermAdaptiveManager):
         _LOGGER.info("Modbus setup completed successfully for %s", self._host)
 
         self.installed_components = 0
+        components_read = False
+
         system_id = await self._read_holding_uint32(MODBUS_REGISTER_SYSTEM_ID)
         if system_id is not None:
+            components_read = True
             self._device_type = system_id >> 24
             _LOGGER.debug("Device type = %s", self.get_device_type)
             _LOGGER.debug("Installed components (2) = %s", hex(system_id & 0xFFFF))
@@ -253,16 +256,21 @@ class DanthermDevice(DanthermModbus, DanthermAdaptiveManager):
             MODBUS_REGISTER_SYSTEM_ID_COMPONENTS
         )
         if system_id_components is not None:
+            components_read = True
             _LOGGER.debug(
                 "Installed components (610) = %s", hex(system_id_components & 0xFFFF)
             )
             self.installed_components |= system_id_components & 0xFFFF
 
-        if self.installed_components:
-            _LOGGER.debug("Installed components = %s", hex(self.installed_components))
-        else:
+        if not components_read:
             _LOGGER.warning("Could not read installed components from device")
-            return None
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+            self._attr_available = False
+            raise ValueError("Could not read installed components from device")
+
+        _LOGGER.debug("Installed components = %s", hex(self.installed_components))
 
         fw_version = await self._read_holding_uint32(MODBUS_REGISTER_FIRMWARE_VERSION)
         if fw_version is not None:

--- a/custom_components/dantherm/device.py
+++ b/custom_components/dantherm/device.py
@@ -91,6 +91,7 @@ from .modbus import (
     MODBUS_REGISTER_SERIAL_NUMBER,
     MODBUS_REGISTER_SUPPLY_TEMP,
     MODBUS_REGISTER_SYSTEM_ID,
+    MODBUS_REGISTER_SYSTEM_ID_COMPONENTS,
     MODBUS_REGISTER_WEEK_PROGRAM_SELECTION,
     ABSwitchPosition,
     DanthermModbus,
@@ -237,16 +238,34 @@ class DanthermDevice(DanthermModbus, DanthermAdaptiveManager):
         _LOGGER.debug("Setup has started")
 
         # Connect and verify modbus connection
-        result = await self.connect_and_verify()
+        if not await self.connect_and_verify():
+            # We shoud never get here since connect_and_verify should raise an exception
+            # if it fails, but just in case, we return None to indicate setup failure
+            return None
         _LOGGER.info("Modbus setup completed successfully for %s", self._host)
-        self.installed_components = result & 0xFFFF
-        _LOGGER.debug("Installed components (610) = %s", hex(self.installed_components))
 
+        self.installed_components = 0
         system_id = await self._read_holding_uint32(MODBUS_REGISTER_SYSTEM_ID)
         if system_id is not None:
             self._device_type = system_id >> 24
             _LOGGER.debug("Device type = %s", self.get_device_type)
             _LOGGER.debug("Installed components (2) = %s", hex(system_id & 0xFFFF))
+            self.installed_components |= system_id & 0xFFFF
+
+        system_id_components = await self._read_holding_uint32(
+            MODBUS_REGISTER_SYSTEM_ID_COMPONENTS
+        )
+        if system_id_components is not None:
+            _LOGGER.debug(
+                "Installed components (610) = %s", hex(system_id_components & 0xFFFF)
+            )
+            self.installed_components |= system_id_components & 0xFFFF
+
+        if self.installed_components:
+            _LOGGER.debug("Installed components = %s", hex(self.installed_components))
+        else:
+            _LOGGER.warning("Could not read installed components from device")
+            return None
 
         fw_version = await self._read_holding_uint32(MODBUS_REGISTER_FIRMWARE_VERSION)
         if fw_version is not None:

--- a/custom_components/dantherm/modbus.py
+++ b/custom_components/dantherm/modbus.py
@@ -126,7 +126,7 @@ class DanthermModbus:
         self._attr_available = True
         return True
 
-    async def connect_and_verify(self) -> int | bool:
+    async def connect_and_verify(self) -> bool:
         """Connect to Modbus and verify connection with retries."""
 
         _LOGGER.debug("Attempting Modbus connection for %s", self._host)
@@ -138,13 +138,11 @@ class DanthermModbus:
 
         _LOGGER.debug("Modbus connection established, verifying connection")
         for _ in range(5):
-            result = await self._read_holding_uint32(
-                MODBUS_REGISTER_SYSTEM_ID_COMPONENTS
-            )
+            result = await self._read_holding_uint32(MODBUS_REGISTER_SYSTEM_ID)
             if result is not None:
                 _LOGGER.debug("Modbus client is connected!")
                 self._attr_available = True
-                return result
+                return True
             await asyncio.sleep(1)
 
         _LOGGER.error("Modbus client failed to respond for %s", self._host)


### PR DESCRIPTION
This pull request improves the initialization and component detection logic for Dantherm devices by refining how installed components are determined and simplifying the Modbus connection verification process. The changes ensure more robust setup handling and clearer logging, especially when reading device information via Modbus.

**Device initialization improvements:**

* The logic for determining installed components was updated to read and combine values from both `MODBUS_REGISTER_SYSTEM_ID` and the newly added `MODBUS_REGISTER_SYSTEM_ID_COMPONENTS`. This ensures that all component information is captured, with appropriate logging and fallback behavior if the data cannot be read. [[1]](diffhunk://#diff-13121ca9cec0747958a3aefaf71829ab01a2d3568b40c86f4c331b252ddeab0aR94) [[2]](diffhunk://#diff-13121ca9cec0747958a3aefaf71829ab01a2d3568b40c86f4c331b252ddeab0aL240-R268)

**Modbus connection verification simplification:**

* The `connect_and_verify` method in `modbus.py` was refactored to only return a boolean indicating connection success, rather than returning component data. The verification now checks the `MODBUS_REGISTER_SYSTEM_ID` register and improves clarity in the connection process. [[1]](diffhunk://#diff-4ececb935af1ddad9ed547b6adbdcf9e1c5ef1ee3f89ab89b3b48246134a762fL129-R129) [[2]](diffhunk://#diff-4ececb935af1ddad9ed547b6adbdcf9e1c5ef1ee3f89ab89b3b48246134a762fL141-R145)