### PR TITLE
Bump Home Assistant minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Home Assistant integration for Dantherm ventilation units.
 
 This custom integration requires:
 
-- Home Assistant version **2025.1.0** or newer
+- Home Assistant version **2025.8.0** or newer
 
 Only support for Modbus over TCP/IP.
 

--- a/custom_components/dantherm/config_flow.py
+++ b/custom_components/dantherm/config_flow.py
@@ -1,5 +1,7 @@
 """Config Flow implementation."""
 
+from __future__ import annotations
+
 import contextlib
 import ipaddress
 import logging


### PR DESCRIPTION
Raise the documented Home Assistant requirement to 2025.8.0 and add `from __future__ import annotations` to the config flow module for forward-compatible typing.